### PR TITLE
Fix one singular CHARACTER of code that broke loading levels with wires

### DIFF
--- a/WillYouSnailLevelFormat/Level.cs
+++ b/WillYouSnailLevelFormat/Level.cs
@@ -142,7 +142,7 @@ namespace WillYouSnailLevelFormat
                 string ID2 = Lines[CurrentLine + 2];
                 int Index2 = int.Parse(Lines[CurrentLine + 3]);
                 level.Connections.Add(new Wire(new ElementReference(Index1, ID1), new ElementReference(Index2, ID2)));
-                CurrentLine += 4;
+                CurrentLine += 3;
             }
 
 


### PR DESCRIPTION
This was unfixed for 2 years... Lmao.